### PR TITLE
Switch to more reliable directory by Fixme

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,7 @@ Meteor.startup(function() {
 
 	// Check Spaces Interval
 	Meteor.setInterval(function() {
-		// -- check all 
+		// -- check all
 		Meteor.call('checkSpaces')
 			// -- check just one
 			//var checkedCount = checkSpace('NURDSpace');
@@ -37,7 +37,7 @@ Meteor.publish('spaces', function() {
 Meteor.methods({
 	checkSpaces: function() {
 		log('checkSpaces');
-		var response = HTTP.get('http://spaceapi.net/directory.json?api=>0.11', { timeout: 5000 });
+		var response = HTTP.get('https://spaceapi.fixme.ch/directory.json', { timeout: 5000 });
 		if (response.statusCode === 200) {
 			var spaceDict = JSON.parse(response.content);
 			var spaceIds = _.keys(spaceDict);
@@ -190,7 +190,7 @@ function quickPatches() {
 		Spaces.update({ _id: space._id }, { $set: { 'data.location.lat': space.data.location.lon, 'data.location.lon': space.data.location.lat } })
 		log('Patched: '.white + 'Codersfield [lat-lon bug]'.yellow);
 	}
-	
+
 	// Kamloops MakerSpace
 	var space = Spaces.findOne({ name: "Kamloops MakerSpace" });
 	if (space && space.data && space.data.location) {


### PR DESCRIPTION
The current SpaceAPI is quite broken. The directory is down right now for example.

We forked the project recently: https://spacedirectory.org/ In that context, we recommend using the [directory by fixme.ch](https://spaceapi.fixme.ch/). It has been maintained for quite a while now, and is also used in the MyHackerspace app for Android.

Note that the fixme API does not provide lookups like filtering by version or space. But that's not really needed anyways, since the entire directory response is quite small and could also be cached. (It also looks like the `checkSpace` method isn't actually being used and could probably be removed. It still contains a reference to the broken directory by spaceapi.net.)

The change also has the benefit that https is being used.

Cheers from Coredump, Switzerland!